### PR TITLE
added a csv annotation use case

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,6 +287,29 @@ The use cases are divided into five sections: annotations that target only the e
 
     </section>
     <section>
+      <h2>Annotating a Region of a CSV</h2>
+      <p>
+      A user would like to make a comment about a particular row, column or 
+      set of cells in a CSV file that has been published on the Web. The comment
+      could be a simple textual description, that is attributed to a particular
+      user, at a particular time.
+      </p>
+      <h3>Examples</h3>
+      <ul>
+        <li>Sue has downloaded a CSV for use in her own statistical analysis
+        tool. She has generated a new column of averages and wants to 
+        republish the CSV on the Web, with a comment about how this column 
+        was calculated, so that the original publisher can determine what
+        has changed and why.</li>
+        <li>Travis and Jen are collaboratively editing a spreadsheet in a
+        Web application. Jen has a question for Travis about some of the data
+        he entered on a particular row. She highlights the row, and attaches
+        her question. Travis can see this annotation on the Web page, and when
+        he downloads the CSV he also gets a metadata file that describes these
+        changes, which he can use in his own spreadsheet application.</li>
+      </ul>
+    </section>
+    <section>
       <h2>Annotation Comparing Segments within a Publication</h2>
         <p>
         A user wishes to annotate two or more parts of a publication, embedded resources, or part of an embedded resource, in order to compare or contrast the targets. This may be to point out inconsistencies in the content or rendering, to make a note about two similar or related passages, or to link part of an embedded resource to where it is referenced in the text.  


### PR DESCRIPTION
I'm working with the HathiTrust Research Center to demonstrate how they could augment their existing CSV metadata with CSV on the Web metadata. In particular we are trying to show how edits to the data performed in spreadsheet applications like OpenRefine could be expressed as annotations on their original CSV. 

The CSV on the Web Working Group is currently looking at using OpenAnnotation annotations as "notes" on specific regions of a CSV. They are also looking at using [RFC 7111](https://tools.ietf.org/html/rfc7111) fragment URIs as the target of the annotation. Tim Cole and Jacob Jett of HTRC at the University of Illinois asked if I would add a use case for annotating CSV to the dpub-annotation documentation. I'm happy to tweak it further if you think it needs more work. 
